### PR TITLE
Slim down image to 15 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM debian:12-slim
+FROM alpine:3.20
 
 # Add inotify-tools for inotifywait
 #
 # We also install curl as scripts using this image often
 # call HTTP webhooks.
-RUN apt-get -y update &&  apt-get install -y \
-    curl \
-    inotify-tools \
-    jq \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl inotify-tools jq
 
 # Set our working directory
 WORKDIR /app

--- a/monitor.sh
+++ b/monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -exo pipefail
 


### PR DESCRIPTION
Base the image off Alpine to get another nice size saving:

    REPOSITORY                             TAG         IMAGE ID      CREATED        SIZE
    localhost/inotify                      alpine      0346632c3067  4 hours ago    15 MB
    localhost/inotify                      debian      2d99b1b27626  4 hours ago    94 MB

Functionality remains the same.